### PR TITLE
app/page.tsx: make footer visible

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -180,7 +180,7 @@ export default function Home() {
           <aside className="flex flex-col w-full p-3">{thumbsRight}</aside>
         </div>
       </div>
-      <footer className="bg-[#100715] text-center py-10 mt-32">
+      <footer className="bg-[#100715] text-gray-600 text-center py-10 mt-32">
         source code:{" "}
         <a
           className="underline"


### PR DESCRIPTION
By default, the footer text is rendered in black.
It will make it merge into the background and effectively invisible.

In this PR, I assign a "text-gray-600" to the footer to fix it.